### PR TITLE
new 2023 lexicon support

### DIFF
--- a/cross-country/example.gpx
+++ b/cross-country/example.gpx
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" creator="YOUR APPLICATION NAME HERE" version="1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:openrally="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.2" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd
-                      http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.2 openrally.xsd">
+  xmlns:openrally="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd
+                      http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3 openrally.xsd">
 
   <metadata>
     <extensions>
@@ -62,6 +62,84 @@
     <extensions>
       <openrally:distance>0.51</openrally:distance>
       <openrally:fn/>
+    </extensions>
+  </wpt>
+
+  <!-- Neutralized fuel stop with Speed Zone, 15 mins (900 seconds) -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.5</openrally:distance>
+      <openrally:neutralization>900</openrally:neutralization>
+      <openrally:dz>40</openrally:dz>
+      <openrally:fuel/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.51</openrally:distance>
+      <openrally:fn/>
+      <openrally:fz/>
+    </extensions>
+  </wpt>
+
+  <!-- Transfer with Speed Limit -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.5</openrally:distance>
+      <openrally:dt/>
+      <openrally:dz>40</openrally:dz>
+      <openrally:fuel/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.51</openrally:distance>
+      <openrally:ft/>
+      <openrally:fz/>
+    </extensions>
+  </wpt>
+
+  <!-- WP Types -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>10</openrally:distance>
+      <openrally:wpm open="1000" clear="50" name="1"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>20</openrally:distance>
+      <openrally:wps open="1000" clear="50" name="2"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>30</openrally:distance>
+      <openrally:wpc open="1000" clear="50" name="3"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>40</openrally:distance>
+      <openrally:wpv open="1000" clear="50" name="4"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>50</openrally:distance>
+      <openrally:wpe open="1000" clear="50" name="5"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>60</openrally:distance>
+      <openrally:wpn open="1000" clear="50" name="6"/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>70</openrally:distance>
+      <openrally:wpp open="1000" clear="50" name="7"/>
     </extensions>
   </wpt>
 

--- a/cross-country/openrally.xsd
+++ b/cross-country/openrally.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.2"
-  xmlns:svg="http://www.w3.org/2000/svg" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.2">
+  xmlns="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3"
+  xmlns:svg="http://www.w3.org/2000/svg" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3">
 
   <xs:element name="units" type="unitsType">
     <!-- The valid "units" are "metric" or "statute". Under "metric", route distances are in kilometers, speeds are in kph, and waypoint radii are in meters. Under the "statute" measurement system, route distances are in statute miles, speeds are in mph, and waypoint radii are in yards. -->
@@ -33,6 +33,8 @@
   <xs:element name="wps" type="waypointType"/>
   <xs:element name="wpc" type="waypointType"/>
   <xs:element name="wpv" type="waypointType"/>
+  <xs:element name="wpp" type="waypointType"/>
+  <xs:element name="wpn" type="waypointType"/>
   <!--
   Duplicate of "wpe" <xs:element name="waypointeclipse" type="markerType"/>
   Duplicate of "wps" <xs:element name="waypointsafety" type="markerType"/>
@@ -43,16 +45,20 @@
   <xs:element name="notes" type="drawingType"/>
   <!-- other control points -->
   <xs:element name="stop" type="timeType" default="0"/>
-  <xs:element name="checkpoint" type="namedType"/>
+  <xs:element name="checkpoint" type="waypointType"/>
   <xs:element name="neutralization" type="timeType"/>
   <!-- DEPRECATION WARNING: "neutralization" should be renamed to "sn" at next major version.-->
-  <xs:element name="fn" type="markerType"/>
+  <xs:element name="fn" type="waypointType"/>
   <xs:element name="timecontrol" type="timeLimitType"/>
   <xs:element name="fuel" type="markerType"/>
   <xs:element name="reset" type="distanceType" default="0"/>
 
   <!-- Instruct consumer to allow display of GPS coords for this WPT -->
   <xs:element name="show_coordinates" type="markerType"/>
+
+<!-- Transfer Sections-->
+  <xs:element name="dt" type="waypointType"/>
+  <xs:element name="ft" type="waypointType"/>
 
   <!--
   Duplicate of "stop" <xs:element name="stopcontrol" type="markerType"/>

--- a/cross-country/test_wrapper.xsd
+++ b/cross-country/test_wrapper.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema elementFormDefault="qualified"
     xmlns="http://www.w3.org/2001/XMLSchema">
-    <import namespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.1" schemaLocation="openrally.xsd"/>
+    <import namespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3" schemaLocation="openrally.xsd"/>
     <import namespace="http://www.topografix.com/GPX/1/1" schemaLocation="../common/gpx-strict.xsd"/>
 </schema>


### PR DESCRIPTION
Support for 2023 FIA/Dakar Lexicon: 

- WPP
- WPN
- change Check Point to a "waypoint" type (open and clear radii)
- add DT and FT (transfers)

Also updated tests, example, and validate script.